### PR TITLE
Add configureInterfaces call

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,7 +11,7 @@ the default behavior will suffice.
   - [terminate()](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#terminate)
   - [configureClock(microseconds, peripheral)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configureclockmicroseconds-peripheral)
   - [configureSocketPort(port)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configuresocketportport)
-  - [configureInterfaces(ifFlags)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configureinterfaces)
+  - [configureInterfaces(ifFlags)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configureinterfacesifflags)
 
 #### Constants
   - [CLOCK_PWM](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#clock_pwm)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,10 +11,14 @@ the default behavior will suffice.
   - [terminate()](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#terminate)
   - [configureClock(microseconds, peripheral)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configureclockmicroseconds-peripheral)
   - [configureSocketPort(port)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configuresocketportport)
+  - [configureInterfaces(ifFlags)](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#configureinterfaces)
 
 #### Constants
   - [CLOCK_PWM](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#clock_pwm)
   - [CLOCK_PCM](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#clock_pcm)
+  - [DISABLE_FIFO_IF](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#disable_fifo_if)
+  - [DISABLE_SOCK_IF](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#disable_sock_if)
+  - [LOCALHOST_SOCK_IF](https://github.com/fivdi/pigpio/blob/master/doc/configuration.md#localhost_sock_if)
 
 ### Functions
 
@@ -184,6 +188,27 @@ pigpio.configureSocketPort(8889);
 led = new Gpio(17, {mode: Gpio.OUTPUT});
 ```
 
+#### configureInterfaces(ifFlags)
+- ifFlags - flags to configure the fifo and socket interfaces.
+
+Configures pigpio support of the fifo and socket interfaces.
+
+The default setting (0) is that both interfaces are enabled.
+
+If `configureInterfaces` is called, it must be called before creating `Gpio`
+objects. For example:
+
+```js
+var pigpio = require('pigpio'),
+  Gpio = pigpio.Gpio,
+  led;
+
+// Call configureInterfaces before creating Gpio objects
+pigpio.configureInterfaces(pigpio.DISABLE_FIFO_IF | pigpio.DISABLE_SOCK_IF);
+
+led = new Gpio(17, {mode: Gpio.OUTPUT});
+```
+
 ### Constants
 
 #### CLOCK_PWM
@@ -192,3 +217,11 @@ PWM clock.
 #### CLOCK_PCM
 PCM clock.
 
+#### DISABLE_FIFO_IF
+Disables the pipe interface.
+
+#### DISABLE_SOCK_IF
+Disables the socket interface.
+
+#### LOCALHOST_SOCK_IF
+Disables remote socket access (this means that the socket interface is only usable from the local Pi).

--- a/pigpio.js
+++ b/pigpio.js
@@ -312,6 +312,13 @@ module.exports.configureSocketPort = function (port) {
   pigpio.gpioCfgSocketPort(+port);
 };
 
+module.exports.configureInterfaces = function (ifFlags) {
+  pigpio.gpioCfgInterfaces(+ifFlags);
+};
+
 module.exports.CLOCK_PWM = 0; // PI_CLOCK_PWM;
 module.exports.CLOCK_PCM = 1; // PI_CLOCK_PCM;
 
+module.exports.DISABLE_FIFO_IF = 1; // PI_DISABLE_FIFO_IF
+module.exports.DISABLE_SOCK_IF = 2; // PI_DISABLE_SOCK_IF
+module.exports.LOCALHOST_SOCK_IF = 4; // PI_LOCALHOST_SOCK_IF

--- a/src/pigpio.cc
+++ b/src/pigpio.cc
@@ -687,6 +687,17 @@ NAN_METHOD(gpioCfgSocketPort) {
 }
 
 
+NAN_METHOD(gpioCfgInterfaces) {
+  if (info.Length() < 1 || !info[0]->IsUint32()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "gpioCfgInterfaces", ""));
+  }
+
+  unsigned ifFlags = info[0]->Uint32Value();
+
+  gpioCfgInterfaces(ifFlags);
+}
+
+
 /*static void SetConst(
   Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target,
   const char* name,
@@ -793,6 +804,7 @@ NAN_MODULE_INIT(InitAll) {
 
   SetFunction(target, "gpioCfgClock", gpioCfgClock);
   SetFunction(target, "gpioCfgSocketPort", gpioCfgSocketPort);
+  SetFunction(target, "gpioCfgInterfaces", gpioCfgInterfaces);
 }
 
 NODE_MODULE(pigpio, InitAll)


### PR DESCRIPTION
This can be used to disable the often undesirable FIFO and socket listeners (TCP 8888) that pigpio opens by default, and which can also be a security hole.