### PR TITLE
add operating system declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pigpio",
   "version": "1.2.0",
   "description": "Fast GPIO, PWM, servo control, state change notification, and interrupt handling on the Raspberry Pi",
+  "os": [
+    "linux"
+  ],
   "main": "pigpio.js",
   "directories": {
     "example": "example",


### PR DESCRIPTION
When developing an app on something other than linux NPM will fail more gracefully when `pigpio` is included in `optionalDependencies`.