### PR TITLE
Add TypeScript types from DefinitelyTyped, extended for 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Fast GPIO, PWM, servo control, state change notification, and interrupt handling on the Raspberry Pi",
   "main": "pigpio.js",
+  "types": "pigpio.d.ts",
   "directories": {
     "example": "example",
     "test": "test"

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -1,0 +1,454 @@
+// Type definitions for pigpio 1.2
+// Project: https://github.com/fivdi/pigpio
+// Definitions by: ManerFan <https://github.com/manerfan>
+//                 erikma <https://github.com/erikma>
+//                 park012241 <https://github.com/park012241>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+
+/************************************
+ * Gpio
+ ************************************/
+
+/**
+ * General Purpose Input Output
+ */
+export class Gpio extends EventEmitter {
+    /**
+     * Returns a new Gpio object for accessing a GPIO
+     * @param gpio      an unsigned integer specifying the GPIO number
+     * @param options   object (optional)
+     */
+    constructor(
+        gpio: number,
+        options?: {
+            /**
+             * INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5 (optional, no default)
+             */
+            mode?: number;
+
+            /**
+             * PUD_OFF, PUD_DOWN, or PUD_UP (optional, no default)
+             */
+            pullUpDown?: number;
+
+            /**
+             * interrupt edge for inputs. RISING_EDGE, FALLING_EDGE, or EITHER_EDGE (optional, no default)
+             */
+            edge?: number;
+
+            /**
+             * interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout if edge specified)
+             */
+            timeout?: number;
+
+            /**
+             * boolean specifying whether or not alert events are emitted when the GPIO changes state (optional, default false)
+             */
+            alert?: boolean
+        }
+    );
+
+    /**
+     * Sets the GPIO mode.
+     * @param mode  INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5
+     */
+    mode(mode: number): Gpio;
+
+    /**
+     * Sets or clears the resistor pull type for the GPIO.
+     * @param pud   PUD_OFF, PUD_DOWN, or PUD_UP
+     */
+    pullUpDown(pud: number): Gpio;
+
+    /**
+     * Returns the GPIO mode.
+     */
+    getMode(): number;
+
+    /**
+     * Returns the GPIO level, 0 or 1.
+     */
+    digitalRead(): number;
+
+    /**
+     * Sets the GPIO level to 0 or 1. If PWM or servo pulses are active on the GPIO they are switched off.
+     * @param level     0 or 1
+     */
+    digitalWrite(level: number): Gpio;
+
+    /**
+     * Sends a trigger pulse to the GPIO. The GPIO is set to level for pulseLen microseconds and then reset to not level.
+     * @param pulseLen  pulse length in microseconds (1 - 100)
+     * @param level     0 or 1
+     */
+    trigger(pulseLen: number, level: number): Gpio;
+
+    /**
+     * Starts PWM on the GPIO. Returns this.
+     * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
+     */
+    pwmWrite(dutyCycle: number): Gpio;
+
+    /**
+     * The same to #pwmWrite.
+     * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
+     */
+    analogWrite(dutyCycle: number): Gpio;
+
+    /**
+     * Starts hardware PWM on the GPIO at the specified frequency and dutyCycle. Frequencies above 30MHz are unlikely to work.
+     * @param frequency     an unsigned integer >= 0 and <= 125000000
+     * @param dutyCycle     an unsigned integer >= 0 (off) and <= 1000000 (fully on).
+     */
+    hardwarePwmWrite(frequency: number, dutyCycle: number): Gpio;
+
+    /**
+     * Returns the PWM duty cycle setting on the GPIO.
+     */
+    getPwmDutyCycle(): number;
+
+    /**
+     * Selects the duty cycle range to be used for the GPIO. Subsequent calls to pwmWrite will use a duty cycle between 0 (off) and range (fully on).
+     * @param range     an unsigned integer in the range 25 through 40000
+     */
+    pwmRange(range: number): Gpio;
+
+    /**
+     * Returns the duty cycle range used for the GPIO.
+     * If hardware PWM is active on the GPIO the reported range will be 1000000.
+     */
+    getPwmRange(): number;
+
+    /**
+     * Returns the real range used for the GPIO.
+     * If hardware PWM is active on the GPIO the reported real range will be approximately 250M divided by the set PWM frequency.
+     */
+    getPwmRealRange(): number;
+
+    /**
+     * Sets the frequency in hertz to be used for the GPIO. Returns this.
+     * @param frequency      an unsigned integer >= 0
+     */
+    pwmFrequency(frequency: number): Gpio;
+
+    /**
+     * Returns the frequency (in hertz) used for the GPIO. The default frequency is 800Hz.
+     */
+    getPwmFrequency(): number;
+
+    /**
+     * Starts servo pulses at 50Hz on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise)
+     * @param pulseWidth    pulse width in microseconds, an unsigned integer, 0 or a number in the range 500 through 2500
+     */
+    servoWrite(pulseWidth: number): Gpio;
+
+    /**
+     * Returns the servo pulse width setting on the GPIO.
+     */
+    getServoPulseWidth(): number;
+
+    /**
+     * Enables interrupts for the GPI
+     * @param edge      RISING_EDGE, FALLING_EDGE, or EITHER_EDGE
+     * @param timeout   interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout)
+     */
+    enableInterrupt(edge: number, timeout?: number): Gpio;
+
+    /**
+     * Disables interrupts for the GPIO. Returns this.
+     */
+    disableInterrupt(): Gpio;
+
+    /**
+     * Enables alerts for the GPIO. Returns this.
+     */
+    enableAlert(): Gpio;
+
+    /**
+     * Disables aterts for the GPIO. Returns this.
+     */
+    disableAlert(): Gpio;
+
+    /**
+     * Sets a glitch filter on a GPIO. Returns this.
+     * @param steady    Time, in microseconds, during which the level must be stable. Maximum value: 300000
+     */
+    glitchFilter(steady: number): Gpio;
+
+    /*----------------------*
+     * mode
+     *----------------------*/
+
+    /**
+     * Indicates that the GPIO is an input.
+     */
+    static INPUT: number;
+
+    /**
+     * Indicates that the GPIO is an output.
+     */
+    static OUTPUT: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 0.
+     */
+    static ALT0: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 1.
+     */
+    static ALT1: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 2.
+     */
+    static ALT2: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 03.
+     */
+    static ALT3: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 4.
+     */
+    static ALT4: number;
+
+    /**
+     * Indicates that the GPIO is in alternative mode 5.
+     */
+    static ALT5: number;
+
+    /*----------------------*
+     * pud
+     *----------------------*/
+
+    /**
+     * Niether the pull-up nor the pull-down resistor should be enabled.
+     */
+    static PUD_OFF: number;
+
+    /**
+     * Enable pull-down resistor.
+     */
+    static PUD_DOWN: number;
+
+    /**
+     * Enable pull-up resistor.
+     */
+    static PUD_UP: number;
+
+    /*----------------------*
+     * isr
+     *----------------------*/
+
+    /**
+     * Indicates that the GPIO fires interrupts on rising edges.
+     */
+    static RISING_EDGE: number;
+
+    /**
+     * Indicates that the GPIO fires interrupts on falling edges.
+     */
+    static FALLING_EDGE: number;
+
+    /**
+     * Indicates that the GPIO fires interrupts on both rising and falling edges.
+     */
+    static EITHER_EDGE: number;
+
+    /*----------------------*
+     * timeout
+     *----------------------*/
+
+    /**
+     * The level argument passed to an interrupt event listener when an interrupt timeout expires.
+     */
+    static TIMEOUT: number;
+
+    /*----------------------*
+     * gpio numbers
+     *----------------------*
+
+    /**
+     * The smallest GPIO number.
+     */
+    static MIN_GPIO: number;
+
+    /**
+     * The largest GPIO number.
+     */
+    static MAX_GPIO: number;
+
+    /**
+     * The largest user GPIO number.
+     */
+    static MAX_USER_GPIO: number;
+}
+
+/************************************
+ * GpioBank
+ ************************************
+
+ /**
+  * Banked General Purpose Input Output
+  */
+export class GpioBank {
+    /**
+     * Returns a new GpioBank object for accessing up to 32 GPIOs as one operation.
+     * @param bank  BANK1 or BANK2 (optional, defaults to BANK1)
+     */
+    constructor(bank?: number);
+
+    /**
+     * Returns the current level of all GPIOs in the bank.
+     */
+    read(): number;
+
+    /**
+     * For each GPIO in the bank, sets the GPIO level to 1 if the corresponding bit in bits is set.
+     * @param bits  a bit mask of the the GPIOs to set to 1
+     */
+    set(bits: number): GpioBank;
+
+    /**
+     * For each GPIO in the bank, sets the GPIO level to 0 if the corresponding bit in bits is set.
+     * @param bits   a bit mask of the the GPIOs to clear or set to 0
+     */
+    clear(bits: number): GpioBank;
+
+    /**
+     * Returns the bank identifier (BANK1 or BANK2.)
+     */
+    bank(): number;
+
+    /**
+     * Identifies bank 1.
+     */
+    static BANK1: number;
+
+    /**
+     * Identifies bank 2.
+     */
+    static BACK2: number;
+}
+
+/************************************
+ * Notifier
+ ************************************
+
+ /**
+  * Notification Stream
+  */
+export class Notifier {
+    /**
+     * Returns a new Notifier object that contains a stream which provides notifications about state changes on any of GPIOs 0 through 31 concurrently.
+     * @param options   Used to configure which GPIOs notifications should be provided for.
+     */
+    constructor(options?: {
+        /**
+         * a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
+         * If a bit is set, the corresponding GPIO will be monitored for state changes. (optional, no default)
+         */
+        bits: number;
+    })
+
+    /**
+     * Starts notifications for the GPIOs specified in the bit mask.
+     * @param bits  a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
+     * If a bit is set, the corresponding GPIO will be monitored for state changes.
+     */
+    start(bits: number): Notifier;
+
+    /**
+     * Stops notifications. Notifications can be restarted with the start method.
+     */
+    stop(): Notifier;
+
+    /**
+     * Stops notifications and releases resources.
+     */
+    close(): Notifier;
+
+    /**
+     * Returns the notification stream which is a Readable stream.
+     */
+    stream(): NodeJS.ReadableStream;
+
+    /**
+     * The number of bytes occupied by a notification in the notification stream.
+     */
+    static NOTIFICATION_LENGTH: number;
+
+    /**
+     * Indicates a keep alive signal on the stream and is sent once a minute in the absence of other notification activity.
+     */
+    static PI_NTFY_FLAGS_ALIVE: number;
+}
+
+/************************************
+ * Configuration
+ ************************************/
+
+/**
+ * PI_CLOCK_PWM
+ */
+export const CLOCK_PWM: number;
+
+/**
+ * PI_CLOCK_PCM
+ */
+export const CLOCK_PCM: number;
+
+/**
+ * Initialize the pigpio package
+ */
+export function initialize(): void;
+
+/**
+ * Terminate the pigpio package
+ */
+export function terminate(): void;
+
+/**
+ * The configureClock function can be used to configure the sample rate and timing peripheral.
+ * @param microseconds  an unsigned integer specifying the sample rate in microseconds (1, 2, 4, 5, 8, or 10)
+ * @param peripheral    an unsigned integer specifying the peripheral for timing (CLOCK_PWM or CLOCK_PCM)
+ */
+export function configureClock(microseconds: number, peripheral: number): void;
+
+/**
+ * Configures pigpio to use the specified socket port.
+ * The default setting is to use port 8888.
+ * If configureSocketPort is called, it must be called before creating Gpio objects.
+ * @param port          an unsigned integer specifying the pigpio socket port number
+ */
+export function configureSocketPort(port: number): void;
+
+/**
+ * Returns the Raspberry Pi hardware revision as an unsigned integer. Returns 0
+ * if the hardware revision can not be determined.
+ */
+export function hardwareRevision(): number;
+
+/**
+ * Gets the current unsigned 32-bit integer value of the number of microseconds
+ * since system boot. This value wraps around the 32-bit space in just over an hour.
+ * Use tickDiff() to get the difference between two tick values, to
+ * ensure the correct JavaScript operations are used to account for the possibility
+ * of overflow.
+ */
+export function getTick(): number;
+
+/**
+ * Returns the difference in microseconds between the end and start tick counts.
+ * The tick counts can be retrieved using getTick(), or may be passed
+ * in a GPIO event callback.
+ * @param startTick    The start of the measured interval. An unsigned integer tick value.
+ * @param endTick      The end of the measured interval. An unsigned integer tick value.
+ */
+export function tickDiff(startTick: number, endTick: number): number;

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pigpio 1.3
+// Type definitions for pigpio 2.0
 // Project: https://github.com/fivdi/pigpio
 // Definitions by: ManerFan <https://github.com/manerfan>
 //                 erikma <https://github.com/erikma>
@@ -102,7 +102,7 @@ export class Gpio extends EventEmitter {
 
   /**
    * Starts hardware PWM on the GPIO at the specified frequency and dutyCycle. Frequencies above 30MHz are unlikely to work.
-   * @param frequency     an unsigned integer >= 0 and <= 125000000
+   * @param frequency     an unsigned integer >= 0 and <= 125000000 (>= 0 and <= 187500000 for the BCM2711)
    * @param dutyCycle     an unsigned integer >= 0 (off) and <= 1000000 (fully on).
    */
   hardwarePwmWrite(frequency: number, dutyCycle: number): Gpio;
@@ -126,7 +126,7 @@ export class Gpio extends EventEmitter {
 
   /**
    * Returns the real range used for the GPIO.
-   * If hardware PWM is active on the GPIO the reported real range will be approximately 250M divided by the set PWM frequency.
+   * If hardware PWM is active on the GPIO the reported real range will be approximately 250M (375M for the BCM2711) divided by the set PWM frequency.
    */
   getPwmRealRange(): number;
 

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -1061,6 +1061,13 @@ export function hardwareRevision(): number;
  * Use tickDiff() to get the difference between two tick values, to
  * ensure the correct JavaScript operations are used to account for the possibility
  * of overflow.
+ * @example
+ * let startUsec = pigpio.getTick();
+ *
+ * // Do some time-consuming things.
+ *
+ * let currentUsec = pigpio.getTick();
+ * let deltaUsec = pigpio.tickDiff(startUsec, currentUsec);
  */
 export function getTick(): number;
 
@@ -1070,5 +1077,12 @@ export function getTick(): number;
  * in a GPIO event callback.
  * @param startTick    The start of the measured interval. An unsigned integer tick value.
  * @param endTick      The end of the measured interval. An unsigned integer tick value.
+ * @example
+ * let startUsec = pigpio.getTick();
+ *
+ * // Do some time-consuming things.
+ *
+ * let currentUsec = pigpio.getTick();
+ * let deltaUsec = pigpio.tickDiff(startUsec, currentUsec);
  */
 export function tickDiff(startTick: number, endTick: number): number;

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -48,7 +48,7 @@ export class Gpio extends EventEmitter {
             /**
              * boolean specifying whether or not alert events are emitted when the GPIO changes state (optional, default false)
              */
-            alert?: boolean
+            alert?: boolean;
         }
     );
 
@@ -272,7 +272,7 @@ export class Gpio extends EventEmitter {
 
     /*----------------------*
      * gpio numbers
-     *----------------------*
+     *----------------------*/
 
     /**
      * The smallest GPIO number.
@@ -294,9 +294,9 @@ export class Gpio extends EventEmitter {
  * GpioBank
  ************************************
 
- /**
-  * Banked General Purpose Input Output
-  */
+/**
+ * Banked General Purpose Input Output
+ */
 export class GpioBank {
     /**
      * Returns a new GpioBank object for accessing up to 32 GPIOs as one operation.
@@ -341,9 +341,9 @@ export class GpioBank {
  * Notifier
  ************************************
 
- /**
-  * Notification Stream
-  */
+/**
+ * Notification Stream
+ */
 export class Notifier {
     /**
      * Returns a new Notifier object that contains a stream which provides notifications about state changes on any of GPIOs 0 through 31 concurrently.
@@ -355,7 +355,7 @@ export class Notifier {
          * If a bit is set, the corresponding GPIO will be monitored for state changes. (optional, no default)
          */
         bits: number;
-    })
+    });
 
     /**
      * Starts notifications for the GPIOs specified in the bit mask.

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -17,277 +17,277 @@ import { EventEmitter } from 'events';
  * General Purpose Input Output
  */
 export class Gpio extends EventEmitter {
-    /**
-     * Returns a new Gpio object for accessing a GPIO
-     * @param gpio      an unsigned integer specifying the GPIO number
-     * @param options   object (optional)
-     */
-    constructor(
-        gpio: number,
-        options?: {
-            /**
-             * INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5 (optional, no default)
-             */
-            mode?: number;
+  /**
+   * Returns a new Gpio object for accessing a GPIO
+   * @param gpio      an unsigned integer specifying the GPIO number
+   * @param options   object (optional)
+   */
+  constructor(
+    gpio: number,
+    options?: {
+      /**
+       * INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5 (optional, no default)
+       */
+      mode?: number;
 
-            /**
-             * PUD_OFF, PUD_DOWN, or PUD_UP (optional, no default)
-             */
-            pullUpDown?: number;
+      /**
+       * PUD_OFF, PUD_DOWN, or PUD_UP (optional, no default)
+       */
+      pullUpDown?: number;
 
-            /**
-             * interrupt edge for inputs. RISING_EDGE, FALLING_EDGE, or EITHER_EDGE (optional, no default)
-             */
-            edge?: number;
+      /**
+       * interrupt edge for inputs. RISING_EDGE, FALLING_EDGE, or EITHER_EDGE (optional, no default)
+       */
+      edge?: number;
 
-            /**
-             * interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout if edge specified)
-             */
-            timeout?: number;
+      /**
+       * interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout if edge specified)
+       */
+      timeout?: number;
 
-            /**
-             * boolean specifying whether or not alert events are emitted when the GPIO changes state (optional, default false)
-             */
-            alert?: boolean;
-        }
-    );
+      /**
+       * boolean specifying whether or not alert events are emitted when the GPIO changes state (optional, default false)
+       */
+      alert?: boolean;
+    }
+  );
 
-    /**
-     * Sets the GPIO mode.
-     * @param mode  INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5
-     */
-    mode(mode: number): Gpio;
+  /**
+   * Sets the GPIO mode.
+   * @param mode  INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5
+   */
+  mode(mode: number): Gpio;
 
-    /**
-     * Sets or clears the resistor pull type for the GPIO.
-     * @param pud   PUD_OFF, PUD_DOWN, or PUD_UP
-     */
-    pullUpDown(pud: number): Gpio;
+  /**
+   * Sets or clears the resistor pull type for the GPIO.
+   * @param pud   PUD_OFF, PUD_DOWN, or PUD_UP
+   */
+  pullUpDown(pud: number): Gpio;
 
-    /**
-     * Returns the GPIO mode.
-     */
-    getMode(): number;
+  /**
+   * Returns the GPIO mode.
+   */
+  getMode(): number;
 
-    /**
-     * Returns the GPIO level, 0 or 1.
-     */
-    digitalRead(): number;
+  /**
+   * Returns the GPIO level, 0 or 1.
+   */
+  digitalRead(): number;
 
-    /**
-     * Sets the GPIO level to 0 or 1. If PWM or servo pulses are active on the GPIO they are switched off.
-     * @param level     0 or 1
-     */
-    digitalWrite(level: number): Gpio;
+  /**
+   * Sets the GPIO level to 0 or 1. If PWM or servo pulses are active on the GPIO they are switched off.
+   * @param level     0 or 1
+   */
+  digitalWrite(level: number): Gpio;
 
-    /**
-     * Sends a trigger pulse to the GPIO. The GPIO is set to level for pulseLen microseconds and then reset to not level.
-     * @param pulseLen  pulse length in microseconds (1 - 100)
-     * @param level     0 or 1
-     */
-    trigger(pulseLen: number, level: number): Gpio;
+  /**
+   * Sends a trigger pulse to the GPIO. The GPIO is set to level for pulseLen microseconds and then reset to not level.
+   * @param pulseLen  pulse length in microseconds (1 - 100)
+   * @param level     0 or 1
+   */
+  trigger(pulseLen: number, level: number): Gpio;
 
-    /**
-     * Starts PWM on the GPIO. Returns this.
-     * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
-     */
-    pwmWrite(dutyCycle: number): Gpio;
+  /**
+   * Starts PWM on the GPIO. Returns this.
+   * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
+   */
+  pwmWrite(dutyCycle: number): Gpio;
 
-    /**
-     * The same to #pwmWrite.
-     * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
-     */
-    analogWrite(dutyCycle: number): Gpio;
+  /**
+   * The same to #pwmWrite.
+   * @param dutyCycle     an unsigned integer >= 0 (off) and <= range (fully on). range defaults to 255.
+   */
+  analogWrite(dutyCycle: number): Gpio;
 
-    /**
-     * Starts hardware PWM on the GPIO at the specified frequency and dutyCycle. Frequencies above 30MHz are unlikely to work.
-     * @param frequency     an unsigned integer >= 0 and <= 125000000
-     * @param dutyCycle     an unsigned integer >= 0 (off) and <= 1000000 (fully on).
-     */
-    hardwarePwmWrite(frequency: number, dutyCycle: number): Gpio;
+  /**
+   * Starts hardware PWM on the GPIO at the specified frequency and dutyCycle. Frequencies above 30MHz are unlikely to work.
+   * @param frequency     an unsigned integer >= 0 and <= 125000000
+   * @param dutyCycle     an unsigned integer >= 0 (off) and <= 1000000 (fully on).
+   */
+  hardwarePwmWrite(frequency: number, dutyCycle: number): Gpio;
 
-    /**
-     * Returns the PWM duty cycle setting on the GPIO.
-     */
-    getPwmDutyCycle(): number;
+  /**
+   * Returns the PWM duty cycle setting on the GPIO.
+   */
+  getPwmDutyCycle(): number;
 
-    /**
-     * Selects the duty cycle range to be used for the GPIO. Subsequent calls to pwmWrite will use a duty cycle between 0 (off) and range (fully on).
-     * @param range     an unsigned integer in the range 25 through 40000
-     */
-    pwmRange(range: number): Gpio;
+  /**
+   * Selects the duty cycle range to be used for the GPIO. Subsequent calls to pwmWrite will use a duty cycle between 0 (off) and range (fully on).
+   * @param range     an unsigned integer in the range 25 through 40000
+   */
+  pwmRange(range: number): Gpio;
 
-    /**
-     * Returns the duty cycle range used for the GPIO.
-     * If hardware PWM is active on the GPIO the reported range will be 1000000.
-     */
-    getPwmRange(): number;
+  /**
+   * Returns the duty cycle range used for the GPIO.
+   * If hardware PWM is active on the GPIO the reported range will be 1000000.
+   */
+  getPwmRange(): number;
 
-    /**
-     * Returns the real range used for the GPIO.
-     * If hardware PWM is active on the GPIO the reported real range will be approximately 250M divided by the set PWM frequency.
-     */
-    getPwmRealRange(): number;
+  /**
+   * Returns the real range used for the GPIO.
+   * If hardware PWM is active on the GPIO the reported real range will be approximately 250M divided by the set PWM frequency.
+   */
+  getPwmRealRange(): number;
 
-    /**
-     * Sets the frequency in hertz to be used for the GPIO. Returns this.
-     * @param frequency      an unsigned integer >= 0
-     */
-    pwmFrequency(frequency: number): Gpio;
+  /**
+   * Sets the frequency in hertz to be used for the GPIO. Returns this.
+   * @param frequency      an unsigned integer >= 0
+   */
+  pwmFrequency(frequency: number): Gpio;
 
-    /**
-     * Returns the frequency (in hertz) used for the GPIO. The default frequency is 800Hz.
-     */
-    getPwmFrequency(): number;
+  /**
+   * Returns the frequency (in hertz) used for the GPIO. The default frequency is 800Hz.
+   */
+  getPwmFrequency(): number;
 
-    /**
-     * Starts servo pulses at 50Hz on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise)
-     * @param pulseWidth    pulse width in microseconds, an unsigned integer, 0 or a number in the range 500 through 2500
-     */
-    servoWrite(pulseWidth: number): Gpio;
+  /**
+   * Starts servo pulses at 50Hz on the GPIO, 0 (off), 500 (most anti-clockwise) to 2500 (most clockwise)
+   * @param pulseWidth    pulse width in microseconds, an unsigned integer, 0 or a number in the range 500 through 2500
+   */
+  servoWrite(pulseWidth: number): Gpio;
 
-    /**
-     * Returns the servo pulse width setting on the GPIO.
-     */
-    getServoPulseWidth(): number;
+  /**
+   * Returns the servo pulse width setting on the GPIO.
+   */
+  getServoPulseWidth(): number;
 
-    /**
-     * Enables interrupts for the GPI
-     * @param edge      RISING_EDGE, FALLING_EDGE, or EITHER_EDGE
-     * @param timeout   interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout)
-     */
-    enableInterrupt(edge: number, timeout?: number): Gpio;
+  /**
+   * Enables interrupts for the GPI
+   * @param edge      RISING_EDGE, FALLING_EDGE, or EITHER_EDGE
+   * @param timeout   interrupt timeout in milliseconds (optional, defaults to 0 meaning no timeout)
+   */
+  enableInterrupt(edge: number, timeout?: number): Gpio;
 
-    /**
-     * Disables interrupts for the GPIO. Returns this.
-     */
-    disableInterrupt(): Gpio;
+  /**
+   * Disables interrupts for the GPIO. Returns this.
+   */
+  disableInterrupt(): Gpio;
 
-    /**
-     * Enables alerts for the GPIO. Returns this.
-     */
-    enableAlert(): Gpio;
+  /**
+   * Enables alerts for the GPIO. Returns this.
+   */
+  enableAlert(): Gpio;
 
-    /**
-     * Disables aterts for the GPIO. Returns this.
-     */
-    disableAlert(): Gpio;
+  /**
+   * Disables aterts for the GPIO. Returns this.
+   */
+  disableAlert(): Gpio;
 
-    /**
-     * Sets a glitch filter on a GPIO. Returns this.
-     * @param steady    Time, in microseconds, during which the level must be stable. Maximum value: 300000
-     */
-    glitchFilter(steady: number): Gpio;
+  /**
+   * Sets a glitch filter on a GPIO. Returns this.
+   * @param steady    Time, in microseconds, during which the level must be stable. Maximum value: 300000
+   */
+  glitchFilter(steady: number): Gpio;
 
-    /*----------------------*
-     * mode
-     *----------------------*/
+  /*----------------------*
+   * mode
+   *----------------------*/
 
-    /**
-     * Indicates that the GPIO is an input.
-     */
-    static INPUT: number;
+  /**
+   * Indicates that the GPIO is an input.
+   */
+  static INPUT: number;
 
-    /**
-     * Indicates that the GPIO is an output.
-     */
-    static OUTPUT: number;
+  /**
+   * Indicates that the GPIO is an output.
+   */
+  static OUTPUT: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 0.
-     */
-    static ALT0: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 0.
+   */
+  static ALT0: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 1.
-     */
-    static ALT1: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 1.
+   */
+  static ALT1: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 2.
-     */
-    static ALT2: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 2.
+   */
+  static ALT2: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 03.
-     */
-    static ALT3: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 03.
+   */
+  static ALT3: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 4.
-     */
-    static ALT4: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 4.
+   */
+  static ALT4: number;
 
-    /**
-     * Indicates that the GPIO is in alternative mode 5.
-     */
-    static ALT5: number;
+  /**
+   * Indicates that the GPIO is in alternative mode 5.
+   */
+  static ALT5: number;
 
-    /*----------------------*
-     * pud
-     *----------------------*/
+  /*----------------------*
+   * pud
+   *----------------------*/
 
-    /**
-     * Niether the pull-up nor the pull-down resistor should be enabled.
-     */
-    static PUD_OFF: number;
+  /**
+   * Niether the pull-up nor the pull-down resistor should be enabled.
+   */
+  static PUD_OFF: number;
 
-    /**
-     * Enable pull-down resistor.
-     */
-    static PUD_DOWN: number;
+  /**
+   * Enable pull-down resistor.
+   */
+  static PUD_DOWN: number;
 
-    /**
-     * Enable pull-up resistor.
-     */
-    static PUD_UP: number;
+  /**
+   * Enable pull-up resistor.
+   */
+  static PUD_UP: number;
 
-    /*----------------------*
-     * isr
-     *----------------------*/
+  /*----------------------*
+   * isr
+   *----------------------*/
 
-    /**
-     * Indicates that the GPIO fires interrupts on rising edges.
-     */
-    static RISING_EDGE: number;
+  /**
+   * Indicates that the GPIO fires interrupts on rising edges.
+   */
+  static RISING_EDGE: number;
 
-    /**
-     * Indicates that the GPIO fires interrupts on falling edges.
-     */
-    static FALLING_EDGE: number;
+  /**
+   * Indicates that the GPIO fires interrupts on falling edges.
+   */
+  static FALLING_EDGE: number;
 
-    /**
-     * Indicates that the GPIO fires interrupts on both rising and falling edges.
-     */
-    static EITHER_EDGE: number;
+  /**
+   * Indicates that the GPIO fires interrupts on both rising and falling edges.
+   */
+  static EITHER_EDGE: number;
 
-    /*----------------------*
-     * timeout
-     *----------------------*/
+  /*----------------------*
+   * timeout
+   *----------------------*/
 
-    /**
-     * The level argument passed to an interrupt event listener when an interrupt timeout expires.
-     */
-    static TIMEOUT: number;
+  /**
+   * The level argument passed to an interrupt event listener when an interrupt timeout expires.
+   */
+  static TIMEOUT: number;
 
-    /*----------------------*
-     * gpio numbers
-     *----------------------*/
+  /*----------------------*
+   * gpio numbers
+   *----------------------*/
 
-    /**
-     * The smallest GPIO number.
-     */
-    static MIN_GPIO: number;
+  /**
+   * The smallest GPIO number.
+   */
+  static MIN_GPIO: number;
 
-    /**
-     * The largest GPIO number.
-     */
-    static MAX_GPIO: number;
+  /**
+   * The largest GPIO number.
+   */
+  static MAX_GPIO: number;
 
-    /**
-     * The largest user GPIO number.
-     */
-    static MAX_USER_GPIO: number;
+  /**
+   * The largest user GPIO number.
+   */
+  static MAX_USER_GPIO: number;
 }
 
 /************************************
@@ -298,43 +298,43 @@ export class Gpio extends EventEmitter {
  * Banked General Purpose Input Output
  */
 export class GpioBank {
-    /**
-     * Returns a new GpioBank object for accessing up to 32 GPIOs as one operation.
-     * @param bank  BANK1 or BANK2 (optional, defaults to BANK1)
-     */
-    constructor(bank?: number);
+  /**
+   * Returns a new GpioBank object for accessing up to 32 GPIOs as one operation.
+   * @param bank  BANK1 or BANK2 (optional, defaults to BANK1)
+   */
+  constructor(bank?: number);
 
-    /**
-     * Returns the current level of all GPIOs in the bank.
-     */
-    read(): number;
+  /**
+   * Returns the current level of all GPIOs in the bank.
+   */
+  read(): number;
 
-    /**
-     * For each GPIO in the bank, sets the GPIO level to 1 if the corresponding bit in bits is set.
-     * @param bits  a bit mask of the the GPIOs to set to 1
-     */
-    set(bits: number): GpioBank;
+  /**
+   * For each GPIO in the bank, sets the GPIO level to 1 if the corresponding bit in bits is set.
+   * @param bits  a bit mask of the the GPIOs to set to 1
+   */
+  set(bits: number): GpioBank;
 
-    /**
-     * For each GPIO in the bank, sets the GPIO level to 0 if the corresponding bit in bits is set.
-     * @param bits   a bit mask of the the GPIOs to clear or set to 0
-     */
-    clear(bits: number): GpioBank;
+  /**
+   * For each GPIO in the bank, sets the GPIO level to 0 if the corresponding bit in bits is set.
+   * @param bits   a bit mask of the the GPIOs to clear or set to 0
+   */
+  clear(bits: number): GpioBank;
 
-    /**
-     * Returns the bank identifier (BANK1 or BANK2.)
-     */
-    bank(): number;
+  /**
+   * Returns the bank identifier (BANK1 or BANK2.)
+   */
+  bank(): number;
 
-    /**
-     * Identifies bank 1.
-     */
-    static BANK1: number;
+  /**
+   * Identifies bank 1.
+   */
+  static BANK1: number;
 
-    /**
-     * Identifies bank 2.
-     */
-    static BACK2: number;
+  /**
+   * Identifies bank 2.
+   */
+  static BACK2: number;
 }
 
 /************************************
@@ -345,49 +345,49 @@ export class GpioBank {
  * Notification Stream
  */
 export class Notifier {
+  /**
+   * Returns a new Notifier object that contains a stream which provides notifications about state changes on any of GPIOs 0 through 31 concurrently.
+   * @param options   Used to configure which GPIOs notifications should be provided for.
+   */
+  constructor(options?: {
     /**
-     * Returns a new Notifier object that contains a stream which provides notifications about state changes on any of GPIOs 0 through 31 concurrently.
-     * @param options   Used to configure which GPIOs notifications should be provided for.
+     * a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
+     * If a bit is set, the corresponding GPIO will be monitored for state changes. (optional, no default)
      */
-    constructor(options?: {
-        /**
-         * a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
-         * If a bit is set, the corresponding GPIO will be monitored for state changes. (optional, no default)
-         */
-        bits: number;
-    });
+    bits: number;
+  });
 
-    /**
-     * Starts notifications for the GPIOs specified in the bit mask.
-     * @param bits  a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
-     * If a bit is set, the corresponding GPIO will be monitored for state changes.
-     */
-    start(bits: number): Notifier;
+  /**
+   * Starts notifications for the GPIOs specified in the bit mask.
+   * @param bits  a bit mask indicating the GPIOs of interest, bit0 corresponds to GPIO0, bit1 corresponds to GPIO1, ..., bit31 corresponds to GPIO31.
+   * If a bit is set, the corresponding GPIO will be monitored for state changes.
+   */
+  start(bits: number): Notifier;
 
-    /**
-     * Stops notifications. Notifications can be restarted with the start method.
-     */
-    stop(): Notifier;
+  /**
+   * Stops notifications. Notifications can be restarted with the start method.
+   */
+  stop(): Notifier;
 
-    /**
-     * Stops notifications and releases resources.
-     */
-    close(): Notifier;
+  /**
+   * Stops notifications and releases resources.
+   */
+  close(): Notifier;
 
-    /**
-     * Returns the notification stream which is a Readable stream.
-     */
-    stream(): NodeJS.ReadableStream;
+  /**
+   * Returns the notification stream which is a Readable stream.
+   */
+  stream(): NodeJS.ReadableStream;
 
-    /**
-     * The number of bytes occupied by a notification in the notification stream.
-     */
-    static NOTIFICATION_LENGTH: number;
+  /**
+   * The number of bytes occupied by a notification in the notification stream.
+   */
+  static NOTIFICATION_LENGTH: number;
 
-    /**
-     * Indicates a keep alive signal on the stream and is sent once a minute in the absence of other notification activity.
-     */
-    static PI_NTFY_FLAGS_ALIVE: number;
+  /**
+   * Indicates a keep alive signal on the stream and is sent once a minute in the absence of other notification activity.
+   */
+  static PI_NTFY_FLAGS_ALIVE: number;
 }
 
 /************************************

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for pigpio 1.2
+// Type definitions for pigpio 1.3
 // Project: https://github.com/fivdi/pigpio
 // Definitions by: ManerFan <https://github.com/manerfan>
 //                 erikma <https://github.com/erikma>
 //                 park012241 <https://github.com/park012241>
+//                 Cameron Tacklind <https://github.com/cinderblock>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -428,6 +429,42 @@ export function configureClock(microseconds: number, peripheral: number): void;
  * @param port          an unsigned integer specifying the pigpio socket port number
  */
 export function configureSocketPort(port: number): void;
+
+/**
+ * Bit Mask used to configure interfaces
+ * Disables the FIFO socket file
+ */
+export const DISABLE_FIFO_IF: 1;
+/**
+ * Bit Mask used to configure interfaces
+ * Disables the network socket interface
+ */
+export const DISABLE_SOCK_IF: 2;
+/**
+ * Bit Mask used to configure interfaces
+ * Forces network socket interface to only listen on localhost
+ */
+export const LOCALHOST_SOCK_IF: 4;
+/**
+ * Bit Mask used to configure interfaces
+ * Disables alerts
+ */
+export const DISABLE_ALERT: 8;
+
+/**
+ * Configures pigpio to use the specified socket port.
+ * The default setting is 0 which enables
+ * - the socket file FIFO interface
+ * - the network socket interface on all interfaces
+ *
+ * If configureInterfaces is called, it must be called before creating Gpio objects.
+ * @param interfaceMask an unsigned integer specifying a bitwise combination of Interfaces to use. A bitwise OR of a subset of:
+ * - DISABLE_FIFO_IF
+ * - DISABLE_SOCK_IF
+ * - LOCALHOST_SOCK_IF
+ * - DISABLE_ALERT
+ */
+export function configureInterfaces(interfaceMask: number): void;
 
 /**
  * Returns the Raspberry Pi hardware revision as an unsigned integer. Returns 0

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -54,6 +54,152 @@ export class Gpio extends EventEmitter {
   );
 
   /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  addListener(
+    event: 'alert',
+    listener: (level: 0 | 1, tick: number) => void
+  ): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  on(event: 'alert', listener: (level: 0 | 1, tick: number) => void): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  once(event: 'alert', listener: (level: 0 | 1, tick: number) => void): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  prependListener(
+    event: 'alert',
+    listener: (level: 0 | 1, tick: number) => void
+  ): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  prependOnceListener(
+    event: 'alert',
+    listener: (level: 0 | 1, tick: number) => void
+  ): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  removeListener(
+    event: 'alert',
+    listener: (level: 0 | 1, tick: number) => void
+  ): this;
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  listeners(event: 'alert'): ((level: 0 | 1, tick: number) => void)[];
+
+  /**
+   * Alerts are emitted every time a Gpio changes state
+   * @param event Alert Event
+   * @param listener Function to handle the event
+   */
+  rawListeners(event: 'alert'): ((level: 0 | 1, tick: number) => void)[];
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  addListener(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  on(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  once(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  prependListener(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  prependOnceListener(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  removeListener(
+    event: 'interrupt',
+    listener: (level: 0 | 1 | typeof Gpio.TIMEOUT) => void
+  ): this;
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  listeners(
+    event: 'interrupt'
+  ): ((level: 0 | 1 | typeof Gpio.TIMEOUT) => void)[];
+
+  /**
+   * Interrupts are emitted on Gpio instances with the interrupt enabled
+   * @param event Event
+   * @param listener Function to handle the event
+   */
+  rawListeners(
+    event: 'interrupt'
+  ): ((level: 0 | 1 | typeof Gpio.TIMEOUT) => void)[];
+
+  /**
    * Sets the GPIO mode.
    * @param mode  INPUT, OUTPUT, ALT0, ALT1, ALT2, ALT3, ALT4, or ALT5
    */

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -339,9 +339,23 @@ export class Gpio extends EventEmitter {
   );
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   addListener(
     event: 'alert',
@@ -349,23 +363,65 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   on(event: 'alert', listener: (level: 0 | 1, tick: number) => void): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   once(event: 'alert', listener: (level: 0 | 1, tick: number) => void): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   prependListener(
     event: 'alert',
@@ -373,9 +429,23 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   prependOnceListener(
     event: 'alert',
@@ -383,9 +453,23 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   removeListener(
     event: 'alert',
@@ -393,23 +477,56 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   listeners(event: 'alert'): ((level: 0 | 1, tick: number) => void)[];
 
   /**
-   * Alerts are emitted every time a Gpio changes state
-   * @param event Alert Event
-   * @param listener Function to handle the event
+   * @param level the GPIO level when the state change occurred, 0 or 1
+   * @param tick the time stamp of the state change, an unsigned 32 bit integer
+   * `tick` is the number of microseconds since system boot and it should be accurate to a few microseconds.
+   *
+   * As tick is an unsigned 32 bit quantity it wraps around after 2^32 microseconds, which is approximately 1 hour 12 minutes.
+   *
+   * It's not necessary to worry about wrap around when subtracting one tick from another tick if the JavaScript sign propagating right shift operator >> is used.
+   *
+   * @example <caption>Wrong: simply subtracting startTick from endTick prints -4294967294 which isn't the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log(endTick - startTick); // prints -4294967294 which isn't what we want
+   *
+   * @example <caption>right shifts both startTick and endTick 0 bits to the right before subtracting prints 2 which is the difference we're looking for</caption>
+   * const startTick = 0xffffffff; // 2^32-1 or 4294967295, the max unsigned 32 bit integer
+   * const endTick = 1;
+   * console.log((endTick >> 0) - (startTick >> 0)); // prints 2 which is what we want
    */
   rawListeners(event: 'alert'): ((level: 0 | 1, tick: number) => void)[];
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   addListener(
     event: 'interrupt',
@@ -417,9 +534,14 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   on(
     event: 'interrupt',
@@ -427,9 +549,14 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   once(
     event: 'interrupt',
@@ -437,9 +564,14 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   prependListener(
     event: 'interrupt',
@@ -447,9 +579,14 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   prependOnceListener(
     event: 'interrupt',
@@ -457,9 +594,14 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   removeListener(
     event: 'interrupt',
@@ -467,18 +609,28 @@ export class Gpio extends EventEmitter {
   ): this;
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   listeners(
     event: 'interrupt'
   ): ((level: 0 | 1 | typeof Gpio.TIMEOUT, tick: number) => void)[];
 
   /**
-   * Interrupts are emitted on Gpio instances with the interrupt enabled
-   * @param event Event
-   * @param listener Function to handle the event
+   * @param level - the GPIO level when the interrupt occurred, 0, 1, or TIMEOUT (2)
+   * @param tick - the time stamp of the state change, an unsigned 32 bit integer
+   * You can find more information about ticks in the event `alert`.
+   *
+   * Emitted on interrupts.
+   *
+   * Interrupts can have an optional timeout.
+   * The level argument passed to the interrupt event listener will be TIMEOUT (2) if the optional interrupt timeout expires.
    */
   rawListeners(
     event: 'interrupt'

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -169,9 +169,7 @@ export function waveTxSend(
  * Delays between waves may be added with the delay command.
  * If present Loop Forever must be the last entry in the chain.
  *
- * For example, the following code creates a chain containing four simple waves and chains them together using all the above modifiers.
- *
- * @example
+ * @example <caption>creates a chain containing four simple waves and chains them together using all the above modifiers.</caption>
  * import * as pigpio from 'pigpio';
  *
  * const Gpio = pigpio.Gpio;


### PR DESCRIPTION
Fixes #103.

I added all the definitions in stages in case we want to split things up.

I tried to just copy the documentation as much as possible, including examples.

This could still be improved much more.

One point of possible contention, I used specific number types (like `0` or `1`) for my exported constants while the original DefinitelyTyped kept it as `number`.

I'll run the https://github.com/DefinitelyTyped/DefinitelyTyped#removing-a-package steps once merged and published, unless someone beats me to it.