### PR TITLE
further limit the native build to only arm architecture to allow Linux development

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
     "conditions": [[
       'OS == "linux"', {
         "conditions": [[
-          '"<!(which pigpiod | wc -l)" != "0"', {
+          '"<!((which pigpiod 2>/dev/null) || echo not_found)" != "not_found"', {
             "include_dirs" : [
               "<!(node -e \"require('nan')\")"
             ],


### PR DESCRIPTION
Trying to develop some code on top of pigpio locally on Linux and running into build issues. This should further limit the build to only Raspberry Pi.

Tested on Arch Linux and Raspberry Pi 3.

Wanted to keep the first check for "Linux" to avoid issues on Windows when running `cat` and `grep` but I don't have a Windows machine to test this on so I'm not 100% sure.