### PR TITLE
Add function and docs for libpigpio's gpioHardwareClock

### DIFF
--- a/doc/gpio.md
+++ b/doc/gpio.md
@@ -15,6 +15,7 @@
 - PWM
   - [pwmWrite(dutyCycle)](#pwmwritedutycycle)
   - [hardwarePwmWrite(frequency, dutyCycle)](#hardwarepwmwritefrequency-dutycycle)
+  - [hardwareClockWrite(frequency)](#hardwareclockwritefrequency)
   - [getPwmDutyCycle()](#getpwmdutycycle)
   - [pwmRange(range)](#pwmrangerange)
   - [getPwmRange()](#getpwmrange)
@@ -195,6 +196,14 @@ have fewer steps. duytCycle is automatically scaled to take this into account.
 
 All models of the Raspberry Pi support hardware PWM on GPIO18.
 
+#### hardwareClockWrite(frequency)
+- frequency - an unsigned integer >= 0 and <= 125000000 (>= 0 and <= 187500000 for the BCM2711)
+
+Starts hardware Clock output on the GPIO at the specified frequency.
+Frequencies above 30MHz are unlikely to work. Returns this.
+
+<!--TODO: Fill this out-->
+
 #### getPwmDutyCycle()
 Returns the PWM duty cycle setting on the GPIO.
 
@@ -286,7 +295,7 @@ The frequencies in hertz for each sample rate are:
 Returns the frequency (in hertz) used for the GPIO. The default frequency is
 800Hz.
 
-If hardware PWM is active on the GPIO the reported frequency will be that set
+If hardware PWM or Clock is active on the GPIO the reported frequency will be that set
 by hardwarePwmWrite.
 
 #### servoWrite(pulseWidth)

--- a/pigpio.d.ts
+++ b/pigpio.d.ts
@@ -691,6 +691,12 @@ export class Gpio extends EventEmitter {
   hardwarePwmWrite(frequency: number, dutyCycle: number): Gpio;
 
   /**
+   * Starts hardware Clock output on the GPIO at the specified frequency. Frequencies above 30MHz are unlikely to work.
+   * @param frequency     an unsigned integer >= 0 and <= 125000000 (>= 0 and <= 187500000 for the BCM2711)
+   */
+  hardwareClockWrite(frequency: number): Gpio;
+
+  /**
    * Returns the PWM duty cycle setting on the GPIO.
    */
   getPwmDutyCycle(): number;

--- a/pigpio.js
+++ b/pigpio.js
@@ -220,6 +220,11 @@ class Gpio extends EventEmitter {
     return this;
   }
 
+  hardwareClockWrite(frequency) {
+    pigpio.gpioHardwareClock(this.gpio, +frequency);
+    return this;
+  }
+
   getPwmDutyCycle() {
     return pigpio.gpioGetPWMdutycycle(this.gpio);
   }

--- a/src/pigpio.cc
+++ b/src/pigpio.cc
@@ -285,6 +285,23 @@ NAN_METHOD(gpioHardwarePWM) {
 }
 
 
+NAN_METHOD(gpioHardwareClock) {
+  if (info.Length() < 2 ||
+      !info[0]->IsUint32() ||
+      !info[1]->IsUint32()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "gpioHardwareClock", ""));
+  }
+
+  unsigned gpio = Nan::To<uint32_t>(info[0]).FromJust();
+  unsigned frequency = Nan::To<uint32_t>(info[1]).FromJust();
+
+  int rc = gpioHardwareClock(gpio, frequency);
+  if (rc < 0) {
+    return ThrowPigpioError(rc, "gpioHardwareClock");
+  }
+}
+
+
 NAN_METHOD(gpioGetPWMdutycycle) {
   if (info.Length() < 1 || !info[0]->IsUint32()) {
     return Nan::ThrowError(Nan::ErrnoException(EINVAL, "gpioGetPWMdutycycle", ""));
@@ -1035,6 +1052,7 @@ NAN_MODULE_INIT(InitAll) {
 
   SetFunction(target, "gpioPWM", gpioPWM);
   SetFunction(target, "gpioHardwarePWM", gpioHardwarePWM);
+  SetFunction(target, "gpioHardwareClock", gpioHardwareClock);
   SetFunction(target, "gpioGetPWMdutycycle", gpioGetPWMdutycycle);
   SetFunction(target, "gpioSetPWMrange", gpioSetPWMrange);
   SetFunction(target, "gpioGetPWMrange", gpioGetPWMrange);


### PR DESCRIPTION
Note, there is a [minor issue with `getPwmFrequency()`](https://github.com/joan2937/pigpio/issues/557) that prevents it from always reading the correct output frequency.